### PR TITLE
Update schedule date for Mickens video

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Mon Jul 13 | Let's Build a Microservice!                       | 45 min  | [Slid
 Mon Jul 27 | I read the UI Events Spec (and all I got were...) | 45 min  | [Slides](https://github.com/nmielnik/notes/blob/master/dom-events/lunch-talk-07-27-2015.md)
 Fri Aug 07 | Implementing a Strong Code Review Culture         | 60 min  | [Link](resources/2015-08-07)
 Wed Aug 26 | Fun with Feature Flags                            | 45 min  | Content TBD
-Fri Aug 28 | Not Even Close The State of Computer Security     | 30 min  | [Video](https://youtu.be/O0uCeq3vb34)
+Fri Sep 4  | Not Even Close The State of Computer Security     | 30 min  | [Video](https://vimeo.com/135347162)
 
 ## Rules
 


### PR DESCRIPTION
Update to avoid conflict realized from further comments on: https://github.com/websdev/lunch/pull/28

Also update video link to one that includes slides: https://vimeo.com/135347162